### PR TITLE
add github link

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1,6 +1,7 @@
 [{
   "Name": "wc",
   "Description": "Plugin to count words/characters in micro",
+  "Website": "https://github.com/adamnpeace/micro-wc-plugin",
   "Tags": ["wc", "word", "character", "count"],
   "Versions": [
     {


### PR DESCRIPTION
This adds the github link so that the repo can be found from the [plugin page](https://micro-editor.github.io/plugins.html).