### PR TITLE
Retab and replace %S to %w, for wordCount.

### DIFF
--- a/wc.lua
+++ b/wc.lua
@@ -12,26 +12,28 @@ function init()
 end
 
 function wordCount(bp)
-	-- Buffer of selection/whole document
-	local buffer
-	--Get active cursor (to get selection)
-	local cursor = bp.Buf:GetActiveCursor()
-	--If cursor exists and there is selection, convert selection byte[] to string
-	if cursor and cursor:HasSelection() then
-		buffer = util.String(cursor:GetSelection())
-	else
-	--no selection, convert whole buffer byte[] to string
-    	buffer = util.String(bp.Buf:Bytes())
+    -- Buffer of selection/whole document
+    local buffer
+    --Get active cursor (to get selection)
+    local cursor = bp.Buf:GetActiveCursor()
+    --If cursor exists and there is selection, convert selection byte[] to string
+    if cursor and cursor:HasSelection() then
+        buffer = util.String(cursor:GetSelection())
+    else
+    --no selection, convert whole buffer byte[] to string
+        buffer = util.String(bp.Buf:Bytes())
     end
     --length of the buffer/selection (string), utf8 friendly
-	charCount = utf8.RuneCountInString(buffer)
-	--Get word/line count using gsub's number of substitutions
-	-- number of substitutions, pattern: %S+ (more than one non-whitespace characters)
-	local _ , wordCount = buffer:gsub("%S+","")
-	-- number of substitutions, pattern: \n (number of newline characters)
-	local _, lineCount = buffer:gsub("\n", "")
-	--add one to line count (since we're counting separators not lines above)
-	lineCount = lineCount + 1
-	--display the message
-	micro.InfoBar():Message("Lines:" .. lineCount .. "  Words:"..wordCount.."  Characters:"..charCount)
+    charCount = utf8.RuneCountInString(buffer)
+    --Get word/line count using gsub's number of substitutions
+    -- number of substitutions, pattern: %w+ (more than one non-whitespace characters)
+    local _ , wordCount = buffer:gsub("%w+","")
+    -- number of substitutions, pattern: \n (number of newline characters)
+    local _, lineCount = buffer:gsub("\n", "")
+    --add one to line count (since we're counting separators not lines above)
+    lineCount = lineCount + 1
+    --display the message
+    micro.InfoBar():Message("Lines:" .. lineCount .. "  Words:"..wordCount.."  Characters:"..charCount)
+    -- number of substitutions, pattern: %w+ (more than one non-whitespace characters)
+    local _ , wordCount = buffer:gsub("%w+","")
 end


### PR DESCRIPTION
Perhaps personal decision, but phrases interspersed by non [ _-] characters are likely dividing characters, like ., for example, so it's likelier to be more accurate by targeting \w imo! Otherwise it's just a retabbing for editor equivalence on all editors/systems.